### PR TITLE
Add direct link to Essay.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cypherpunk-Women
 
-This is a place where bitcoiners can add resources to an interactive version of an essay from the "Cypherpunk Women" anthology by [Cita Press](https://citapress.org/#books/cypherpunk-women/web). The essay is just a small part of a longer anthology available for download at the Cita Press website. 
+This is a place where bitcoiners can add resources to an [interactive version of an essay](Essay.md) from the "Cypherpunk Women" anthology by [Cita Press](https://citapress.org/#books/cypherpunk-women/web). The essay is just a small part of a longer anthology available for download at the Cita Press website.
 
 This particular excerpt includes some of the women pioneers who helped invent the bitcoin ecosystem. Some female contributors, like the original inventor Satoshi and many other male contributors, prefer to stay pseudonymous or anonymous. However, other contributors are available for hire or citation. This GitHub version of the essay is an ongoing record of such public women bitcoiners, in case anyone wants to hire them or invite them to be speakers at any bitcoin-oriented event or workshop. 
 


### PR DESCRIPTION
Add a direct link to the essay from the main README,
Having a diect link  makes it easier to go there. I'm not sure this is the best place (rendered version [here](https://github.com/laanwj/Cypherpunk-Women/blob/813e88bce6c9e7f06e54bdb257843df4f8cb48bd/README.md)), let me know if you have a better suggestion.